### PR TITLE
Update k8s ZK example

### DIFF
--- a/config/stardog-cluster.yaml
+++ b/config/stardog-cluster.yaml
@@ -167,10 +167,8 @@ metadata:
     app: zk
 spec:
   ports:
-  - port: 2888
-    name: server
-  - port: 3888
-    name: leader-election
+  - port: 2181
+    name: client
   clusterIP: None
   selector:
     app: zk

--- a/config/stardog-cluster.yaml
+++ b/config/stardog-cluster.yaml
@@ -173,6 +173,16 @@ spec:
   selector:
     app: zk
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zk-pdb
+spec:
+  selector:
+    matchLabels:
+      app: zk
+  minAvailable: 2
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
- expose ZK client port through the service
- adds pod disruption budget for ZK