### PR TITLE
Force cache module presence in API example. This is a workaround to the

### DIFF
--- a/examples/api/build.gradle
+++ b/examples/api/build.gradle
@@ -3,6 +3,7 @@ group = "com.complexible.stardog.examples.api"
 dependencies {
 	// server core modules
 	compile "com.complexible.stardog:server:${stardogVersion}@pom"
+	compile "com.complexible.stardog.cache:stardog-cache-core:${stardogVersion}"
 	compile "com.stardog.stark.query:stardog-stark-query-api:${stardogVersion}"
 	compile "com.stardog.stark.io:stardog-stark-io-api:${stardogVersion}"
 	compile "com.stardog.stark.query.io:stardog-stark-query-io:${stardogVersion}"


### PR DESCRIPTION
fact that the cache module is not included as a dep to embedded client.