### PR TITLE
Additional .NET examples

### DIFF
--- a/examples/dotnet/DotNetRDFConsoleSample/DotNetRDFConsoleSample.csproj
+++ b/examples/dotnet/DotNetRDFConsoleSample/DotNetRDFConsoleSample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>DotNetRDFConsoleSample</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="dotNetRDF" Version="2.5.1" />
+  </ItemGroup>
+</Project>

--- a/examples/dotnet/DotNetRDFConsoleSample/Program.cs
+++ b/examples/dotnet/DotNetRDFConsoleSample/Program.cs
@@ -32,25 +32,22 @@ namespace DotNetRDFConsoleSample
                 }
 
                 IStoreTemplate template = stardog.GetDefaultTemplate(DATABASE_NAME);
-                Console.WriteLine("Template ID " + template.ID);
-
                 stardog.CreateStore(template);
             }
 
             using (StardogConnector stardogConn = new StardogConnector(SERVER_URL, DATABASE_NAME, STARDOG_USERNAME, STARDOG_PASSWORD))
             {
-                // Construct the Triple we wish to add
+                // make a triple
                 Graph g = new Graph();
                 INode s = g.CreateBlankNode();
                 INode p = g.CreateUriNode(new Uri(RdfSpecsHelper.RdfType));
                 INode o = g.CreateUriNode(new Uri("http://example.org/Example"));
                 Triple t = new Triple(s, p, o);
 
-                // Now add a Triple to a Graph in the Store
+                // add it to a graph in the store
                 if (stardogConn.UpdateSupported)
                 {
-                    // UpdateGraph takes enumerables of Triples to add/remove or null to indicate none
-                    // Hence why we create a Triple array to pass in the Triple to be added
+                    // UpdateGraph takes lists of Triples to add or remove (or null if you do not want to perform that operation)
                     stardogConn.UpdateGraph("http://example.org/graph", new Triple[] { t }, null);
                 }
                 else
@@ -58,25 +55,26 @@ namespace DotNetRDFConsoleSample
                     throw new Exception("Store does not support triple level updates");
                 }
 
-                // OR load from a file:
+                // ** OR **
+
+                // load from a file:
 
                 //Graph g = new Graph();
                 //g.LoadFromFile("example.rdf");
 
-                //// Set its BaseUri property to the URI we want to save it as
+                //// Set its BaseUri property to the graph URI
                 //g.BaseUri = new Uri("http://example.org/graph");
 
-                //// Now save it to the store
+                //// write it to the store
                 //if (!stardogConn.IsReadOnly)
                 //{
                 //    stardogConn.SaveGraph(g);
                 //}
 
-                // Make a SPARQL Query against the store
+                // Run a SPARQL query
                 object results = stardogConn.Query("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } } LIMIT 100");
                 if (results is SparqlResultSet)
                 {
-                    //Print the results
                     SparqlResultSet rset = (SparqlResultSet)results;
                     foreach (SparqlResult r in rset)
                     {
@@ -85,14 +83,13 @@ namespace DotNetRDFConsoleSample
                 }
                 else
                 {
-                    throw new Exception("Did not get a SPARQL Result Set as expected");
+                    throw new Exception("Result was not a SPARQL result set");
                 }
 
-                // List the Graphs
-                // Making sure that we check this feature is supported first
+                // List the graphs in the store
                 if (stardogConn.ListGraphsSupported)
                 {
-                    //Iterate over the Graph URIs and print them
+                    // print the graph URIs
                     foreach (Uri u in stardogConn.ListGraphs())
                     {
                         Console.WriteLine("GRAPH: {0}", u.ToString());
@@ -103,7 +100,7 @@ namespace DotNetRDFConsoleSample
                     throw new Exception("Store does not support listing graphs");
                 }
 
-                // Now delete the Triple we added earlier in the Store
+                // delete the triple we added earlier
                 if (stardogConn.UpdateSupported)
                 {
                     stardogConn.UpdateGraph("http://example.org/graph", null, new Triple[] { t });
@@ -115,10 +112,7 @@ namespace DotNetRDFConsoleSample
 
             }
 
-            Console.ReadLine();
-
         }
-
        
     }
 }

--- a/examples/dotnet/DotNetRDFConsoleSample/Program.cs
+++ b/examples/dotnet/DotNetRDFConsoleSample/Program.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Linq;
+using VDS.RDF;
+using VDS.RDF.Parsing;
+using VDS.RDF.Query;
+using VDS.RDF.Storage;
+using VDS.RDF.Storage.Management;
+using VDS.RDF.Storage.Management.Provisioning;
+
+namespace DotNetRDFConsoleSample
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // This will print out basic traces of HTTP requests and responses to the Console 
+            Options.HttpDebugging = true;
+
+            const string SERVER_URL = "http://localhost:5820";
+            const string STARDOG_USERNAME = "admin";
+            const string STARDOG_PASSWORD = "admin";
+            const string DATABASE_NAME = "MyDB";
+
+            // using will automatically call Dispose() for us
+            using (StardogServer stardog = new StardogServer(SERVER_URL, STARDOG_USERNAME, STARDOG_PASSWORD))
+            {
+
+                // if the database already exists, delete it
+                if (stardog.ListStores().Contains(DATABASE_NAME))
+                {
+                    stardog.DeleteStore(DATABASE_NAME);
+                }
+
+                IStoreTemplate template = stardog.GetDefaultTemplate(DATABASE_NAME);
+                Console.WriteLine("Template ID " + template.ID);
+
+                stardog.CreateStore(template);
+            }
+
+            using (StardogConnector stardogConn = new StardogConnector(SERVER_URL, DATABASE_NAME, STARDOG_USERNAME, STARDOG_PASSWORD))
+            {
+                // Construct the Triple we wish to add
+                Graph g = new Graph();
+                INode s = g.CreateBlankNode();
+                INode p = g.CreateUriNode(new Uri(RdfSpecsHelper.RdfType));
+                INode o = g.CreateUriNode(new Uri("http://example.org/Example"));
+                Triple t = new Triple(s, p, o);
+
+                // Now add a Triple to a Graph in the Store
+                if (stardogConn.UpdateSupported)
+                {
+                    // UpdateGraph takes enumerables of Triples to add/remove or null to indicate none
+                    // Hence why we create a Triple array to pass in the Triple to be added
+                    stardogConn.UpdateGraph("http://example.org/graph", new Triple[] { t }, null);
+                }
+                else
+                {
+                    throw new Exception("Store does not support triple level updates");
+                }
+
+                // OR load from a file:
+
+                //Graph g = new Graph();
+                //g.LoadFromFile("example.rdf");
+
+                //// Set its BaseUri property to the URI we want to save it as
+                //g.BaseUri = new Uri("http://example.org/graph");
+
+                //// Now save it to the store
+                //if (!stardogConn.IsReadOnly)
+                //{
+                //    stardogConn.SaveGraph(g);
+                //}
+
+                // Make a SPARQL Query against the store
+                object results = stardogConn.Query("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } } LIMIT 100");
+                if (results is SparqlResultSet)
+                {
+                    //Print the results
+                    SparqlResultSet rset = (SparqlResultSet)results;
+                    foreach (SparqlResult r in rset)
+                    {
+                        Console.WriteLine("RESULT: {0}", r.ToString());
+                    }
+                }
+                else
+                {
+                    throw new Exception("Did not get a SPARQL Result Set as expected");
+                }
+
+                // List the Graphs
+                // Making sure that we check this feature is supported first
+                if (stardogConn.ListGraphsSupported)
+                {
+                    //Iterate over the Graph URIs and print them
+                    foreach (Uri u in stardogConn.ListGraphs())
+                    {
+                        Console.WriteLine("GRAPH: {0}", u.ToString());
+                    }
+                }
+                else
+                {
+                    throw new Exception("Store does not support listing graphs");
+                }
+
+                // Now delete the Triple we added earlier in the Store
+                if (stardogConn.UpdateSupported)
+                {
+                    stardogConn.UpdateGraph("http://example.org/graph", null, new Triple[] { t });
+                }
+                else
+                {
+                    throw new Exception("Store does not support triple level updates");
+                }
+
+            }
+
+            Console.ReadLine();
+
+        }
+
+       
+    }
+}
+    

--- a/examples/dotnet/HttpApiConsoleSample/HttpApiConsoleSample.csproj
+++ b/examples/dotnet/HttpApiConsoleSample/HttpApiConsoleSample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>HttpApiConsoleSample</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+</Project>

--- a/examples/dotnet/HttpApiConsoleSample/Program.cs
+++ b/examples/dotnet/HttpApiConsoleSample/Program.cs
@@ -10,12 +10,16 @@ using Newtonsoft.Json.Linq;
 
 namespace HttpApiConsoleSample
 {
+    // helper class for deserializing the response of the
+    // list databases request
     public class DatabaseList
     {
         [JsonProperty("databases")]
         public List<string> Databases { get; set; }
     }
 
+    // helper class for deserializing the response of the
+    // create database request
     public class CreateResponse
     {
         [JsonProperty("message")]

--- a/examples/dotnet/HttpApiConsoleSample/Program.cs
+++ b/examples/dotnet/HttpApiConsoleSample/Program.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace HttpApiConsoleSample
+{
+    public class DatabaseList
+    {
+        [JsonProperty("databases")]
+        public List<string> Databases { get; set; }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            const string SERVER_URL = "http://localhost:5820/";
+            const string STARDOG_USERNAME = "admin";
+            const string STARDOG_PASSWORD = "admin";
+            const string DATABASE_NAME = "MyDB";
+
+            Uri baseServerUri = new Uri(SERVER_URL);
+            CredentialCache requestCredentialsCache = new CredentialCache();
+            requestCredentialsCache.Add(baseServerUri, "Basic", new NetworkCredential(STARDOG_USERNAME, STARDOG_PASSWORD));
+
+            // Get a list of all the server's databases
+
+            HttpWebRequest listDatabasesRequest = (HttpWebRequest)WebRequest.Create(new Uri(baseServerUri, "admin/databases"));
+
+            listDatabasesRequest.ContentType = "application/json";
+            listDatabasesRequest.Credentials = requestCredentialsCache;
+            listDatabasesRequest.Method = "GET";
+
+            using (HttpWebResponse listDatabasesResponse = (HttpWebResponse)listDatabasesRequest.GetResponse())
+            {
+                if (listDatabasesResponse.StatusCode == HttpStatusCode.OK)
+                {
+                    using (var sr = new StreamReader(listDatabasesResponse.GetResponseStream()))
+                    {
+                        var databasesAsJson = sr.ReadToEnd();
+                        var databases = JsonConvert.DeserializeObject<DatabaseList>(databasesAsJson);
+                        if (databases.Databases.Contains(DATABASE_NAME))
+                        {
+                            // Database exists, DROP it
+
+                            HttpWebRequest deleteDatabaseRequest = (HttpWebRequest)WebRequest.Create(new Uri(baseServerUri, $"admin/databases/{DATABASE_NAME}"));
+                            deleteDatabaseRequest.Method = "DELETE";
+                            deleteDatabaseRequest.Credentials = requestCredentialsCache;
+                            using (HttpWebResponse deleteDatabaseResponse = (HttpWebResponse)deleteDatabaseRequest.GetResponse())
+                            {
+                                if (deleteDatabaseResponse.StatusCode == HttpStatusCode.OK)
+                                {
+                                    Console.WriteLine($"Database {DATABASE_NAME} deleted!");
+                                }
+                                else
+                                {
+                                    Console.WriteLine($"ERROR! {deleteDatabaseResponse.StatusDescription}");
+                                }
+                            }
+                        }
+
+                    }
+                }
+            }
+
+            // Create the database
+
+            HttpWebRequest createDatabasesRequest = (HttpWebRequest)WebRequest.Create(new Uri(baseServerUri, "admin/databases"));
+
+            createDatabasesRequest.Credentials = requestCredentialsCache;
+            createDatabasesRequest.Method = "POST";
+            createDatabasesRequest.Accept = "*/*";
+            createDatabasesRequest.Headers.Add("Cache-Control", "no-cache");
+            createDatabasesRequest.Headers.Add("Accept-Encoding", "gzip, deflate, br");
+            createDatabasesRequest.UserAgent = "Stardog DotNet Sample";
+
+            
+            string boundary = "--------------------------" + DateTime.Now.Ticks.ToString("x", NumberFormatInfo.InvariantInfo); ;
+
+            byte[] boundaryBytes = Encoding.ASCII.GetBytes("\r\n--" + boundary + "\r\n");
+            byte[] terminatorBytes = Encoding.ASCII.GetBytes("\r\n--" + boundary + "--\r\n");
+            createDatabasesRequest.ContentType = "multipart/form-data;; boundary=" + boundary;
+
+            JObject json = new JObject();
+            json.Add("dbname", new JValue(DATABASE_NAME));
+            json.Add("options", new JObject());
+
+            JObject file = new JObject();
+            file.Add("filename", new JValue("fileX.ttl"));
+
+            json.Add("files", new JArray() { file });
+
+            using (Stream s = createDatabasesRequest.GetRequestStream())
+            {
+                // Boundary
+                s.Write(boundaryBytes, 0, boundaryBytes.Length);
+
+                // Root Item
+                string rootItem = string.Format("Content-Disposition: form-data; name=\"{0}\"\r\n\r\n{1}", "root", json.ToString());
+                byte[] itemBytes = Encoding.UTF8.GetBytes(rootItem);
+                s.Write(itemBytes, 0, itemBytes.Length);
+
+                // Boundary
+                s.Write(boundaryBytes, 0, boundaryBytes.Length);
+
+                // File Item
+                string fileItem = string.Format("Content-Disposition: form-data; name=\"{0}\"; filename=\"{1}\"\r\n", "fileX.ttl", "fileX.ttl");
+                fileItem += "Content-Type: text/turtle";
+                fileItem += "\r\n\r\n";
+                fileItem += "<urn:a> <urn:b> <urn:c> .";
+                fileItem += "\r\n";
+
+                byte[] fileBytes = Encoding.UTF8.GetBytes(fileItem);
+                s.Write(fileBytes, 0, fileBytes.Length);
+
+                // Then terminating boundary
+                s.Write(terminatorBytes, 0, terminatorBytes.Length);
+                s.Close();
+            }
+
+            using (HttpWebResponse createDatabasesResponse = (HttpWebResponse)createDatabasesRequest.GetResponse())
+            {
+                using (var sr = new StreamReader(createDatabasesResponse.GetResponseStream()))
+                {
+                    var responseText = sr.ReadToEnd();
+                    Console.WriteLine(responseText);
+                }
+            }
+        }
+    }
+}

--- a/examples/dotnet/HttpApiConsoleSample/Program.cs
+++ b/examples/dotnet/HttpApiConsoleSample/Program.cs
@@ -91,6 +91,9 @@ namespace HttpApiConsoleSample
             createDatabasesRequest.Headers.Add("Accept-Encoding", "gzip, deflate, br");
             createDatabasesRequest.UserAgent = "Stardog DotNet Sample";
 
+            // Hand coding multipart requests are tricky. For this section I leaned heavily on the
+            // implementation found in dotNetRDF - see https://github.com/dotnetrdf/dotnetrdf/blob/master/Libraries/dotNetRDF/Storage/Management/StardogServer.cs
+
             string boundary = "--------------------------" + DateTime.Now.Ticks.ToString("x", NumberFormatInfo.InvariantInfo); // just need something unique
 
             byte[] boundaryBytes = Encoding.ASCII.GetBytes("\r\n--" + boundary + "\r\n");

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -1,13 +1,41 @@
 # Stardog .NET Examples
 
-The example project demonstrates how to connect to a Stardog server using [TrinityRDF](https://trinity-rdf.net/) and execute queries using SPARQL and LINQ.
+- [Stardog .NET Examples](#stardog-net-examples)
+  - [Prequisites to run any of the samples](#prequisites-to-run-any-of-the-samples)
+  - [Running an Example](#running-an-example)
+  - [The Examples](#the-examples)
+    - [HTTP API Example](#http-api-example)
+    - [dotNetRDF Example](#dotnetrdf-example)
+    - [TrinityRDF Example](#trinityrdf-example)
+      - [Prerequisites](#prerequisites)
+
+The Stardog .NET examples show how you can use .NET code to connect to a Stardog server, manage Stardog databases and query them.
+
+## Prequisites to run any of the samples
+
+* C# development environment (e.g., Visual Studio Community, Visual Studio for Mac, Visual Studio Code, .NET Core SDK,  etc.)
+
+## Running an Example
+
+In Visual Studio, select the example project you want to run as the Startup Project. 
+Build the project and run the resulting program. The program will connect to Stardog and run several queries and print the results to STDOUT.
+
+## The Examples
+
+### HTTP API Example
+
+This example project demonstrates how to connect to a Stardog server using Stardog's HTTP API and list, create, and drop databases.
+
+### dotNetRDF Example
+
+This example project demonstrates how to connect to a Stardog server using [dotNetRDF](https://github.com/dotnetrdf/dotnetrdf) and list, create, and drop databases; how to insert triples into a graph and query a graph using SPARQL.
+
+### TrinityRDF Example
+
+This example project demonstrates how to connect to a Stardog server using [TrinityRDF](https://trinity-rdf.net/) and execute queries using SPARQL and LINQ.
 
 TrinityRDF provides an object mapper layer similar to Entity Framework for RDF data. The ontologies the sample uses can be found in the solution's `Ontologies/` folder. Trinity RDF discovers the ontologies in the solution's `ontologies.config` file. TrinityRDF uses the ontologies to generate mapping code - `Ontologies/Ontologies.g.cs`. A developer uses this generated code to create object models (see the files under the solution's `ObjectModels/` folder) with annotations that connect the C# object to the RDF data. These object models then allow .NET developers to create powerful applications without the need to learn SPARQL!
 
-## Prerequisites
+#### Prerequisites
+
 * Stardog with a database named "music" populated the data from `./examples/dotnet/TrinityConsoleSample/Ontologies/music_schema.ttl` and [`music.ttl.gz`](https://github.com/stardog-union/stardog-tutorials/blob/master/music/music.ttl.gz) in a named graph called `http://stardog.com/tutorial`
-* C# development environment (e.g., Visual Studio Community, Visual Studio for Mac, Visual Studio Code, .NET Core SDK,  etc.)
-
-## Running the sample
-
-Build the solution and then run the resulting program. The program will connect to Stardog and run several queries and print the results to STDOUT.

--- a/examples/dotnet/StardogDotNetSamples.sln
+++ b/examples/dotnet/StardogDotNetSamples.sln
@@ -2,21 +2,33 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2881138B-762A-484D-966C-8C38F64B0212}"
-        ProjectSection(SolutionItems) = preProject
-                README.md = README.md
-        EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrinityConsoleSample", "TrinityConsoleSample\TrinityConsoleSample.csproj", "{5C32FFE3-D22E-4829-AF93-72AD4CE0C2F8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetRDFConsoleSample", "DotNetRDFConsoleSample\DotNetRDFConsoleSample.csproj", "{128E972A-8599-4863-B4B6-894AE29C57BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HttpApiConsoleSample", "HttpApiConsoleSample\HttpApiConsoleSample.csproj", "{610A0047-ABEC-4BD8-B428-9ACC1315D4F0}"
+EndProject
 Global
-        GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                Debug|Any CPU = Debug|Any CPU
-                Release|Any CPU = Release|Any CPU
-        EndGlobalSection
-        GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                {5C32FFE3-D22E-4829-AF93-72AD4CE0C2F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {5C32FFE3-D22E-4829-AF93-72AD4CE0C2F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {5C32FFE3-D22E-4829-AF93-72AD4CE0C2F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {5C32FFE3-D22E-4829-AF93-72AD4CE0C2F8}.Release|Any CPU.Build.0 = Release|Any CPU
-        EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5C32FFE3-D22E-4829-AF93-72AD4CE0C2F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C32FFE3-D22E-4829-AF93-72AD4CE0C2F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C32FFE3-D22E-4829-AF93-72AD4CE0C2F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C32FFE3-D22E-4829-AF93-72AD4CE0C2F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{128E972A-8599-4863-B4B6-894AE29C57BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{128E972A-8599-4863-B4B6-894AE29C57BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{128E972A-8599-4863-B4B6-894AE29C57BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{128E972A-8599-4863-B4B6-894AE29C57BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{610A0047-ABEC-4BD8-B428-9ACC1315D4F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{610A0047-ABEC-4BD8-B428-9ACC1315D4F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{610A0047-ABEC-4BD8-B428-9ACC1315D4F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{610A0047-ABEC-4BD8-B428-9ACC1315D4F0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 EndGlobal

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ the `ServiceLoader` to make them up.
 1. [CSV example](./examples/cli/virtual/csv/readme.md)
 1. [Docs Examples](./examples/docs/readme.md)
 1. [Database Archetype Extensibility](./examples/foaf/readme.md)
-1. [DotNet Example](./examples/dotnet/README.md)
+1. [DotNet Examples](./examples/dotnet/README.md)
 1. [Function Extensibility](./examples/function/readme.md)
 1. [Transaction Listener](./examples/listener/readme.md)
 1. [Cloud Foundry Example Application](https://github.com/stardog-union/cf-example)


### PR DESCRIPTION
No GitHub issue.

Inspired by recent questions to support.

This adds two examples. One uses dotNetRDF and one uses Stardog's HTTP API. Both examples show how to list, drop and create databases.

Please note the Gradle build will continue to build/run the Trinity RDF example. I'll look into ways of making that more flexible.

Please add additional reviewers in case I missed anyone!
