### PR TITLE
Set .bat file line endings to CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 # intervention with every merge.
 ###############################################################################
 
+*.bat        text eol=crlf
 *.sln        text eol=crlf
 *.csproj     text eol=crlf
 *.vbproj     text eol=crlf


### PR DESCRIPTION
I can't rebase because the .bat files have CRLF line endings but aren't listed in the .gitattributes file. They automatically get rewritten on checkout so there are always outstanding uncommitted changes. 