### PR TITLE
Fixed broken links to javadocs

### DIFF
--- a/examples/api/docs/ConnectionAPIExample.html
+++ b/examples/api/docs/ConnectionAPIExample.html
@@ -198,9 +198,9 @@ and client APIs to perform some basic operations.</p>
                 <a class="pilcrow" href="#section-5">&#182;</a>
               </div>
               <p>You’ll need a server to connect to, obviously.  The <code>Stardog</code>
-class provides a simple <a href="http://docs.stardog.com/java/snarl/com/complexible/common/protocols/server/ServerBuilder.html">builder interface</a> to specify which protocol
+class provides a simple <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/common/protocols/server/ServerBuilder.html">builder interface</a> to specify which protocol
 the server should use (options are HTTP &amp; SNARL) and takes a <code>SocketAddress</code>
-the server should bind to.  This will return you a <a href="http://docs.stardog.com/java/snarl/com/complexible/common/protocols/server/Server.html">Server</a> object which
+the server should bind to.  This will return you a <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/common/protocols/server/Server.html">Server</a> object which
 can be used to start &amp; stop the Stardog server.</p>
 <p>This example shows up to create and start the embedded SNARL server.  Note that
 you can only embed the <em>SNARL</em> server, not HTTP.</p>
@@ -326,7 +326,7 @@ if it does, we want to drop it and re-create so that we can run the example from
                 <a class="pilcrow" href="#section-12">&#182;</a>
               </div>
               <p>Now that we’ve created our database for the example, let’s open a connection to it.  For that we use the
-<a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/ConnectionConfiguration.html">ConnectionConfiguration</a>
+<a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/ConnectionConfiguration.html">ConnectionConfiguration</a>
 to configure and open a new connection to a database.</p>
 <p>We’ll use the configuration to specify which database we want to connect to as well as our login information,
 then we can obtain a new connection.</p>
@@ -366,9 +366,9 @@ so we can begin firing off some queries, so first, we’ll start a new transacti
                 <a class="pilcrow" href="#section-14">&#182;</a>
               </div>
               <p>The SNARL API provides fluent objects for adding &amp; removing data from a database.  Here we’ll use the
-<a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/Adder.html">Adder</a> to read in an N3 file
+<a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/Adder.html">Adder</a> to read in an N3 file
 from disk containing the 10k triples SP2B dataset.  Actually, for RDF data coming from a stream or from
-disk, we’ll use the helper class <a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/IO.html">IO</a>
+disk, we’ll use the helper class <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/IO.html">IO</a>
 for this task.  <code>IO</code> will automatically close the stream once the data has been read.</p>
 
             </div>
@@ -455,7 +455,7 @@ in the <code>Graph</code> into the given context.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-19">&#182;</a>
               </div>
-              <p>Now we’ll use the <a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/Remover.html">Remover</a> to
+              <p>Now we’ll use the <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/Remover.html">Remover</a> to
 remove some data from the database.  <code>Remover</code> has a very similar API to <code>Adder</code>, so this code should look
 somewhat familiar.  It has many of the same methods as <code>Adder</code>, the only difference is that they’ll cause
 the triples to be removed instead of added.</p>
@@ -490,7 +490,7 @@ the triples to be removed instead of added.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-21">&#182;</a>
               </div>
-              <p>A SNARL connection provides <a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/Query.html">parameterized queries</a>
+              <p>A SNARL connection provides <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/Query.html">parameterized queries</a>
 which you can use to easily build and execute SPARQL queries against the database.  First, let’s create a simple
 query that will get all of the statements in the database.</p>
 
@@ -634,7 +634,7 @@ so we can go head and remove the limit and get all the results.</p>
                 <a class="pilcrow" href="#section-29">&#182;</a>
               </div>
               <p>The previous query was just getting the statements in which the value of <code>aURI</code> is the subject.  We can get the
-same results just as easily via the <a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/Getter.html">Getter</a>
+same results just as easily via the <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/Getter.html">Getter</a>
 interface.  <code>Getter</code> is designed to make it easy to list statements matching specific criteria; it’s analogous to
 <code>listStatements</code> or <code>match</code> in the Jena &amp; Sesame APIs respectively.</p>
 <p>So here we’ll create a <code>Getter</code> to obtain the list of statements with <code>aURI</code> as the subject.  If we print those

--- a/examples/api/docs/ConnectionPoolsExample.html
+++ b/examples/api/docs/ConnectionPoolsExample.html
@@ -151,7 +151,7 @@
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-3">&#182;</a>
               </div>
-              <p>In this example, we illustrate the configuration and use of the SNARL <a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/ConnectionPool.html">ConnectionPool</a></p>
+              <p>In this example, we illustrate the configuration and use of the SNARL <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/ConnectionPool.html">ConnectionPool</a></p>
 
             </div>
             
@@ -210,7 +210,7 @@
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-6">&#182;</a>
               </div>
-              <p>Pools are based around a <a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/ConnectionConfiguration.html">ConnectionConfiguration</a>.
+              <p>Pools are based around a <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/ConnectionConfiguration.html">ConnectionConfiguration</a>.
 This configuration tells the pool how to create the new connections as they are needed.</p>
 
             </div>
@@ -228,7 +228,7 @@ This configuration tells the pool how to create the new connections as they are 
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-7">&#182;</a>
               </div>
-              <p>Now we want to create the <a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/ConnectionPoolConfig.html">configuration for our pool</a>.
+              <p>Now we want to create the <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/ConnectionPoolConfig.html">configuration for our pool</a>.
 We start by providing the <code>ConnectionConfiguration</code> we just created, that’s the basis of the pool.  Then
 we can configure some aspects of the pool such as expiration time and maximum size.</p>
 

--- a/examples/api/docs/ExplanationExample.html
+++ b/examples/api/docs/ExplanationExample.html
@@ -238,7 +238,7 @@ to find out <em>why</em> an inference was made.</p>
               </div>
               <p>Open a <code>Connection</code> to the database we just created with the default <code>RL</code> reasoning level.
 We’ll use <code>as(...)</code> to give us a view of the parent connection that exposes the Stardog
-<a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/reasoning/ReasoningConnection.html">reasoning capabilities</a>.</p>
+<a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/reasoning/ReasoningConnection.html">reasoning capabilities</a>.</p>
 
             </div>
             
@@ -343,12 +343,12 @@ we created the <code>Connection</code>, we will see that the statement is inferr
               </div>
               <p>Pretty cool!  Now lets find out <em>why</em> that statement was inferred by the reasoner.  Stardog can
 provide explanations for why an inference was made in the form of a
-<a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/reasoning/Proof.html">Proof</a>.  A <code>Proof</code>
+<a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/reasoning/Proof.html">Proof</a>.  A <code>Proof</code>
 will list the steps the reasoner took to arrive at the conclusion that the triple was inferred.
 To get the explanation, we simply ask the <code>Connection</code> to provide us with the <code>Proof</code> for the given
-<a href="http://docs.stardog.com/java/snarl/com/complexible/common/openrdf/util/Expression.html">Expression</a>.
+<a href="http://docs.stardog.com/javadoc/snarl/com/complexible/common/openrdf/util/Expression.html">Expression</a>.
 An <code>Expression</code> is an OWL Axiom as a collection of RDF statements and are created using
-<a href="http://docs.stardog.com/java/snarl/com/complexible/common/openrdf/util/ExpressionFactory.html">ExpressionFactory</a></p>
+<a href="http://docs.stardog.com/javadoc/snarl/com/complexible/common/openrdf/util/ExpressionFactory.html">ExpressionFactory</a></p>
 
             </div>
             

--- a/examples/api/docs/ReasoningExample.html
+++ b/examples/api/docs/ReasoningExample.html
@@ -189,7 +189,7 @@ reasoning capabilities.</p>
                 <a class="pilcrow" href="#section-5">&#182;</a>
               </div>
               <p>You’ll need a server to connect to, obviously.  The <code>Stardog</code>
-class provides a simple <a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/Stardog.html">builder interface</a> to specify which protocol
+class provides a simple <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/Stardog.html">builder interface</a> to specify which protocol
 the server should use (options are HTTP &amp; SNARL) and takes a <code>SocketAddress</code>
 the server should bind to.  This will return you a <code>Server</code> object which
 can be used to start &amp; stop the Stardog server.</p>
@@ -317,7 +317,7 @@ if it does, we want to drop it and re-create so that we can run the example from
                 <a class="pilcrow" href="#section-12">&#182;</a>
               </div>
               <p>Now that we’ve created our database for the example, lets open a connection to it.  For that we use the
-<a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/SNARLConnectionConfiguration.html">SNARLConnectionConfiguration</a>
+<a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/SNARLConnectionConfiguration.html">SNARLConnectionConfiguration</a>
 to configure and open a new connection to a database.</p>
 <p>We’ll use the configuration to specify which database we want to connect to as well as our login information,
 then we can obtain a new connection.  This is also where you specify the type of reasoning you would like the connection

--- a/examples/api/docs/WaldoAPIExample.html
+++ b/examples/api/docs/WaldoAPIExample.html
@@ -282,7 +282,7 @@ via the SNARL API.</p>
                 <a class="pilcrow" href="#section-9">&#182;</a>
               </div>
               <p>Lets try an example with the basic Waldo API
-We want to view this connection as a <a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/search/SearchConnection.html">searchable connection</a>,
+We want to view this connection as a <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/search/SearchConnection.html">searchable connection</a>,
 so we request a view of the <code>Connection</code> as a <code>SearchConnection</code></p>
 
             </div>
@@ -298,7 +298,7 @@ so we request a view of the <code>Connection</code> as a <code>SearchConnection<
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-10">&#182;</a>
               </div>
-              <p>With that done, let’s create a <a href="http://docs.stardog.com/java/snarl/com/complexible/stardog/api/search/Searcher.html">Searcher</a>
+              <p>With that done, let’s create a <a href="http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/search/Searcher.html">Searcher</a>
 that we can use to run some full text searches over the database.
 Here we will specify that we only want results over a score of <code>0.5</code>, and no more than <code>50</code> results
 for things that match the search term <code>mac</code>.  Stardog’s full text search is backed by <a href="http://lucene.apache.org">Lucene</a>

--- a/examples/api/main/src/com/complexible/stardog/examples/api/ConnectionAPIExample.java
+++ b/examples/api/main/src/com/complexible/stardog/examples/api/ConnectionAPIExample.java
@@ -84,7 +84,7 @@ public class ConnectionAPIExample {
 				// Using the SNARL API
 				// -------------------
 				// Now that we've created our database for the example, let's open a connection to it.  For that we use the
-				// [ConnectionConfiguration](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/ConnectionConfiguration.html)
+				// [ConnectionConfiguration](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/ConnectionConfiguration.html)
 				// to configure and open a new connection to a database.
 				//
 				// We'll use the configuration to specify which database we want to connect to as well as our login information,
@@ -99,9 +99,9 @@ public class ConnectionAPIExample {
 					aConn.begin();
 
 					// The SNARL API provides fluent objects for adding & removing data from a database.  Here we'll use the
-					// [Adder](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/Adder.html) to read in an N3 file
+					// [Adder](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/Adder.html) to read in an N3 file
 					// from disk containing a small subset of the SP2B dataset.  Actually, for RDF data coming from a stream or from
-					// disk, we'll use the helper class [IO](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/IO.html)
+					// disk, we'll use the helper class [IO](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/IO.html)
 					// for this task.  `IO` will automatically close the stream once the data has been read.
 					aConn.add().io()
 					     .format(RDFFormats.TURTLE)
@@ -125,7 +125,7 @@ public class ConnectionAPIExample {
 					// Removing data from a database is just as easy.  Again, we need to start a transaction before making any changes.
 					aConn.begin();
 
-					// Now we'll use the [Remover](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/Remover.html) to
+					// Now we'll use the [Remover](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/Remover.html) to
 					// remove some data from the database.  `Remover` has a very similar API to `Adder`, so this code should look
 					// somewhat familiar.  It has many of the same methods as `Adder`, the only difference is that they'll cause
 					// the triples to be removed instead of added.
@@ -136,7 +136,7 @@ public class ConnectionAPIExample {
 					// Lastly, we'll commit the changes.
 					aConn.commit();
 
-					// A SNARL connection provides [parameterized queries](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/Query.html)
+					// A SNARL connection provides [parameterized queries](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/Query.html)
 					// which you can use to easily build and execute SPARQL queries against the database.  First, let's create a simple
 					// query that will get all of the statements in the database.
 					SelectQuery aQuery = aConn.select("select * where { ?s ?p ?o }");
@@ -171,7 +171,7 @@ public class ConnectionAPIExample {
 					}
 
 					// The previous query was just getting the statements in which the value of `aURI` is the subject.  We can get the
-					// same results just as easily via the [Getter](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/Getter.html)
+					// same results just as easily via the [Getter](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/Getter.html)
 					// interface.  `Getter` is designed to make it easy to list statements matching specific criteria; it's analogous to
 					// `listStatements` or `match` in the Jena & Sesame APIs respectively.
 					//

--- a/examples/api/main/src/com/complexible/stardog/examples/api/ConnectionPoolsExample.java
+++ b/examples/api/main/src/com/complexible/stardog/examples/api/ConnectionPoolsExample.java
@@ -36,7 +36,7 @@ public class ConnectionPoolsExample {
 
 	// Using Connection Pools
 	// -------------------
-	// In this example, we illustrate the configuration and use of the SNARL [ConnectionPool](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/ConnectionPool.html)
+	// In this example, we illustrate the configuration and use of the SNARL [ConnectionPool](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/ConnectionPool.html)
 	public static void main(String[] args) throws Exception {
 		// First need to initialize the Stardog instance which will automatically start the embedded server.
 		Stardog aStardog = Stardog.builder().create();
@@ -50,13 +50,13 @@ public class ConnectionPoolsExample {
 
 				// Create a disk-based database with default settings
 				aAdminConnection.disk("testConnectionPool").create();
-				// Pools are based around a [ConnectionConfiguration](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/ConnectionConfiguration.html).
+				// Pools are based around a [ConnectionConfiguration](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/ConnectionConfiguration.html).
 				// This configuration tells the pool how to create the new connections as they are needed.
 				ConnectionConfiguration aConnConfig = ConnectionConfiguration
 					                                      .to("testConnectionPool")
 					                                      .credentials("admin", "admin");
 
-				// Now we want to create the [configuration for our pool](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/ConnectionPoolConfig.html).
+				// Now we want to create the [configuration for our pool](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/ConnectionPoolConfig.html).
 				// We start by providing the `ConnectionConfiguration` we just created, that's the basis of the pool.  Then
 				// we can configure some aspects of the pool such as expiration time and maximum size.
 				ConnectionPoolConfig aConfig = ConnectionPoolConfig

--- a/examples/api/main/src/com/complexible/stardog/examples/api/ExplanationExample.java
+++ b/examples/api/main/src/com/complexible/stardog/examples/api/ExplanationExample.java
@@ -71,7 +71,7 @@ public class ExplanationExample {
 				aAdminConnection.newDatabase("reasoningTest").create();
 				// Open a `Connection` to the database we just created with reasoning turned on.
 				// We'll use `as(...)` to give us a view of the parent connection that exposes the Stardog
-				// [reasoning capabilities](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/reasoning/ReasoningConnection.html).
+				// [reasoning capabilities](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/reasoning/ReasoningConnection.html).
 				try (ReasoningConnection aReasoningConnection = ConnectionConfiguration.to("reasoningTest")
 				                                                                       .credentials("admin", "admin")
 				                                                                       .reasoning(true)
@@ -112,7 +112,7 @@ public class ExplanationExample {
 
 					// Pretty cool!  Now lets find out _why_ that statement was inferred by the reasoner.  Stardog can
 					// provide explanations for why an inference was made in the form of a
-					// [Proof](http://docs.stardog.com/java/snarl/com/complexible/stardog/reasoning/Proof.html).  A `Proof`
+					// [Proof](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/reasoning/Proof.html).  A `Proof`
 					// will list the steps the reasoner took to arrive at the conclusion that the triple was inferred.
 					// To get the explanation, we simply ask the `Connection` to provide us with the `Proof` for the given
 					// Statement

--- a/examples/api/main/src/com/complexible/stardog/examples/api/ReasoningExample.java
+++ b/examples/api/main/src/com/complexible/stardog/examples/api/ReasoningExample.java
@@ -74,7 +74,7 @@ public class ReasoningExample {
 				// Using reasoning via SNARL
 				// -------------------------
 				// Now that we've created our database for the example, lets open a connection to it.  For that we use the
-				// [ConnectionConfiguration](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/ConnectionConfiguration.html)
+				// [ConnectionConfiguration](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/ConnectionConfiguration.html)
 				// to configure and open a new connection to a database.
 				//
 				// We'll use the configuration to specify which database we want to connect to as well as our login information,

--- a/examples/api/main/src/com/complexible/stardog/examples/api/WaldoAPIExample.java
+++ b/examples/api/main/src/com/complexible/stardog/examples/api/WaldoAPIExample.java
@@ -81,11 +81,11 @@ public class WaldoAPIExample {
 					aConn.commit();
 
 					// Lets try an example with the basic Waldo API
-					// We want to view this connection as a [searchable connection](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/search/SearchConnection.html),
+					// We want to view this connection as a [searchable connection](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/search/SearchConnection.html),
 					// so we request a view of the `Connection` as a `SearchConnection`
 					SearchConnection aSearchConn = aConn.as(SearchConnection.class);
 
-					// With that done, let's create a [Searcher](http://docs.stardog.com/java/snarl/com/complexible/stardog/api/search/Searcher.html)
+					// With that done, let's create a [Searcher](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/api/search/Searcher.html)
 					// that we can use to run some full text searches over the database.
 					// Here we will specify that we only want results over a score of `0.5`, and no more than `50` results
 					// for things that match the search term `mac`.  Stardog's full text search is backed by [Lucene](http://lucene.apache.org)

--- a/examples/function/main/src/com/complexible/stardog/examples/functions/TitleCase.java
+++ b/examples/function/main/src/com/complexible/stardog/examples/functions/TitleCase.java
@@ -40,7 +40,7 @@ public final class TitleCase extends AbstractFunction implements StringFunction 
 
 	// ## Initializing a Function
 	//
-	// This implementation extends from [AbstractFunction](http://docs.stardog.com/java/snarl/com/complexible/stardog/plan/filter/functions/AbstractFunction.html)
+	// This implementation extends from [AbstractFunction](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/plan/filter/functions/AbstractFunction.html)
 	// which takes care of much of the work of creating a custom function.  We're passing in that our new function
 	// `TitleCase` takes a single argument, and that it's name is tag:stardog:api:titleCase.  Note that names
 	// should be URIs.

--- a/examples/function/readme.md
+++ b/examples/function/readme.md
@@ -1,6 +1,6 @@
 # Function Extensibility
 
-The Stardog [com.complexible.stardog.plan.filter.functions.Function](http://docs.stardog.com/java/snarl/com/complexible/stardog/plan/filter/functions/Function.html)
+The Stardog [com.complexible.stardog.plan.filter.functions.Function](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/plan/filter/functions/Function.html)
 interface is the extension point for section 17.6 (Extensible Value Testing) of the [SPARQL spec](http://www.w3.org/TR/2012/PR-sparql11-query-20121108/#extensionFunctions).
 
 `Function` corresponds to built-in expressions used in `FILTER`, `BIND` and `SELECT` expressions, as well as
@@ -9,7 +9,7 @@ SPARQL spec like `sameTerm`, `str`, and `now`.
 
 ## Implementing Custom Functions
 
-The starting point for implementing your own custom function is to extend [AbstractFunction](http://docs.stardog.com/java/snarl/com/complexible/stardog/plan/filter/functions/AbstractFunction.html).
+The starting point for implementing your own custom function is to extend [AbstractFunction](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/plan/filter/functions/AbstractFunction.html).
 This class provides much of the basic scaffolding for implementing a new `Function` from scratch.
 
 If your new function falls into one of the existing categories, it should implement the appropriate marker interface:
@@ -86,7 +86,7 @@ provides a mechanism for creating and using custom aggregates *without* requirin
 ## Implementing a Custom Aggregate
 
 To implement a custom aggregate, you should extend
-[AbstractAggregate](http://docs.stardog.com/java/snarl/com/complexible/stardog/plan/aggregates/AbstractAggregate.html).
+[AbstractAggregate](http://docs.stardog.com/javadoc/snarl/com/complexible/stardog/plan/aggregates/AbstractAggregate.html).
 
 The rules regarding constructor, "copy constructor" and the `copy` method for `Function` apply to `Aggregate` as well.
 

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ For additional information see the DotNet Samples' README file - `./examples/dot
 
 ## Generating Documentation
 
-The Stardog [documentation](http://docs.stardog.com) and its [javadocs](http://docs.stardog.com/java/snarl) are a good
+The Stardog [documentation](http://docs.stardog.com) and its [javadocs](http://docs.stardog.com/javadoc/snarl) are a good
 place to start. But some examples in this repository are annotated using Markdown; they can be processed by
 [Docco](http://jashkenas.github.io/docco/).
 


### PR DESCRIPTION
We have a bunch of links in several `stardog-examples` files into the javadoc online docs. The javadoc site was re-homed from http://docs.stardog.com/java/snarl to http://docs.stardog.com/javadoc/snarl about a year ago; this PR updates the links in the example files to the new docs site.

Note that some of the links are still broken. This appears to be an issue with having some of our classes not being included in the javadoc output. This issue needs to be fixed separately.