### PR TITLE
[PLAT-7133] Upgrade third-party libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # gradle
 .gradle
 gradle.properties
+.project
+.classpath
+.settings/
 build
 examples/.idea/misc.xml
 examples/.idea/modules.xml
@@ -56,6 +59,9 @@ bld/
 
 # Visual Studio 2017 auto generated files
 Generated\ Files/
+
+# VS Code options
+.vscode/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ ext {
 	stardogRepo = project.hasProperty("stardogRepo") ? project.getProperty("stardogRepo") : "http://maven.stardog.com"
 	stardogLib = project.hasProperty("stardogLib") ? project.getProperty("stardogLib") : "."
 
-	guavaVersion = "32.1.3-jre"
+	guavaVersion = "33.2.1-jre"
 	junitVersion = "4.12"
 	rdf4jRuntimeVersion = "2.2.4"
 	slf4jVersion = "2.0.13"
@@ -60,6 +60,7 @@ subprojects {
 
 	sourceSets {
 		all {
+			// work around a Gradle-metadata bug introduced in Guava v32.1.0
 			configurations.all {
 				attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
 			}

--- a/build.gradle
+++ b/build.gradle
@@ -49,9 +49,6 @@ subprojects {
 			version {
 				require "$guavaVersion"
 			}
-			attributes {
-				attribute(Attribute.of("org.gradle.jvm.environment", String),"standard-jvm")
-			}
 			exclude group: "com.google.code.findbugs"
 			exclude group: "com.google.guava", module: "failureaccess"
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,10 @@ ext {
 	distPath = "${projectDir}/dist"
 	stardogRepo = project.hasProperty("stardogRepo") ? project.getProperty("stardogRepo") : "http://maven.stardog.com"
 	stardogLib = project.hasProperty("stardogLib") ? project.getProperty("stardogLib") : "."
+
+	guavaVersion = "32.1.3-jre"
+	junitVersion = "4.12"
+	slf4jVersion = "2.0.13"
 }
 
 allprojects {
@@ -40,10 +44,20 @@ subprojects {
 
 	// common deps
 	dependencies {
-		implementation 'org.slf4j:slf4j-api:1.7.12'
-		implementation 'org.slf4j:slf4j-jdk14:1.7.12'
+		implementation("com.google.guava:guava:$guavaVersion") {
+			version {
+				require "$guavaVersion"
+			}
+			attributes {
+				attribute(Attribute.of("org.gradle.jvm.environment", String),"standard-jvm")
+			}
+			exclude group: "com.google.code.findbugs"
+			exclude group: "com.google.guava", module: "failureaccess"
+		}
+		implementation "org.slf4j:slf4j-api:$slf4jVersion"
+		implementation "org.slf4j:slf4j-jdk14:$slf4jVersion"
 
-		testImplementation 'junit:junit:4.12'
+		testImplementation "junit:junit:$junitVersion"
 	}
 
 	sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ ext {
 
 	guavaVersion = "32.1.3-jre"
 	junitVersion = "4.12"
+	rdf4jRuntimeVersion = "2.2.4"
 	slf4jVersion = "2.0.13"
 }
 
@@ -61,6 +62,11 @@ subprojects {
 	}
 
 	sourceSets {
+		all {
+			configurations.all {
+				attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
+			}
+		}
 		main {
 			java {
 				srcDir 'main/src'

--- a/examples/api/build.gradle
+++ b/examples/api/build.gradle
@@ -24,9 +24,7 @@ dependencies {
 	// external apis
 	implementation "com.complexible.stardog.rdf4j:stardog-rdf4j-core:${stardogVersion}"
 	implementation "com.complexible.stardog.jena:stardog-jena:${stardogVersion}"
-	implementation("org.eclipse.rdf4j:rdf4j-runtime:${rdf4jRuntimeVersion}") {
-		exclude group: "com.google.guava"
-	}
+	implementation "org.eclipse.rdf4j:rdf4j-runtime:${rdf4jRuntimeVersion}"
 }
 
 task execute(type:JavaExec, dependsOn: compileJava) {

--- a/examples/api/build.gradle
+++ b/examples/api/build.gradle
@@ -23,8 +23,10 @@ dependencies {
 
 	// external apis
 	implementation "com.complexible.stardog.rdf4j:stardog-rdf4j-core:${stardogVersion}"
-	implementation "org.eclipse.rdf4j:rdf4j-runtime:2.2.4"
 	implementation "com.complexible.stardog.jena:stardog-jena:${stardogVersion}"
+	implementation("org.eclipse.rdf4j:rdf4j-runtime:${rdf4jRuntimeVersion}") {
+		exclude group: "com.google.guava"
+	}
 }
 
 task execute(type:JavaExec, dependsOn: compileJava) {


### PR DESCRIPTION
As part of the `shiro` upgrade in PLAT-7133 (here's the [PR](https://github.com/stardog-union/stardog/pull/12553)), I also upgraded Guava. This caused a failure when running the Release Test Plan on Jenkins.

The issue was that Guava introduced a metadata change in [v32.1.0](https://github.com/google/guava/releases/tag/v32.1.0) that causes serious heartburn for Gradle v6.*. The `stardog` repo is using v8.something of Gradle, so it builds just fine, but building this repo (in the `test_examples` test of [test-plan.sh](https://github.com/stardog-union/stardog/blob/develop/release-scripts/test-plan.sh#L142)) fails since Gradle v6 is unable to determine if it should use the `jre` or `android` version of Guava.

Here is the Jenkins test run with both of these PRs passing the Release Test Plan: https://jenkins.dev.stardog.com/job/stardog/job/PLAT-7133-upgrade-shiro/14/