### PR TITLE
PLAT-8619:  update gradle stuff to 8.11 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,9 +61,9 @@ subprojects {
 	sourceSets {
 		all {
 			// work around a Gradle-metadata bug introduced in Guava v32.1.0
-			configurations.all {
-				attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
-			}
+//			configurations.all {
+//				attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
+//			}
 		}
 		main {
 			java {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Local execution with Java 21 does not work without these changes.